### PR TITLE
#11 RegisterMockType parameterless overload

### DIFF
--- a/src/Ease.DryIoc/DryIocContainerTestBase.cs
+++ b/src/Ease.DryIoc/DryIocContainerTestBase.cs
@@ -47,7 +47,12 @@ namespace Ease.DryIoc
 			Container.RegisterDelegate<T>(c => factory());
 		}
 
-		protected override void RegisterMockType<T>(Func<Action<Mock<T>>> onMockInstanceCreatedFactory)
+        protected override void RegisterMockType<T>()
+        {
+			RegisterMockType<T>(() => null);
+        }
+
+        protected override void RegisterMockType<T>(Func<Action<Mock<T>>> onMockInstanceCreatedFactory)
 		{
 			Container.Register<T>(made: Made.Of<T>(() => CreateAndInitializeMockInstance(onMockInstanceCreatedFactory)));
 		}

--- a/src/Ease.Unity/UnityContainerTestBase.cs
+++ b/src/Ease.Unity/UnityContainerTestBase.cs
@@ -47,7 +47,12 @@ namespace Ease.Unity
 			Container.RegisterFactory<T>(c => factory(), new ResettableLifetimeManager(Resetter));
 		}
 
-		protected override void RegisterMockType<T>(Func<Action<Mock<T>>> onCreatedCallbackFactory)
+        protected override void RegisterMockType<T>()
+        {
+			RegisterMockType<T>(() => null);
+        }
+
+        protected override void RegisterMockType<T>(Func<Action<Mock<T>>> onCreatedCallbackFactory)
 		{
 			RegisterResettableType<T>(() => CreateAndInitializeMockInstance(onCreatedCallbackFactory));
 		}

--- a/src/Ease/ContainerTestBase.cs
+++ b/src/Ease/ContainerTestBase.cs
@@ -14,6 +14,8 @@ namespace Ease
 			where TImplementation : TInterface, new();
 		abstract protected void RegisterTypeFactory<T>(Func<T> factory)
 			where T : class;
+		abstract protected void RegisterMockType<T>()
+			where T : class;
 		abstract protected void RegisterMockType<T>(Func<Action<Mock<T>>> onCreatedCallbackFactory)
 			where T : class;
 

--- a/tests/CommonFiles/IService.cs
+++ b/tests/CommonFiles/IService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Ease.TestCommon
+{
+	public interface IService
+	{
+		Task LongRunningTask();
+	}
+}

--- a/tests/CommonFiles/ScopeTest.cs
+++ b/tests/CommonFiles/ScopeTest.cs
@@ -67,6 +67,7 @@ namespace Ease.XUnit.Unity.PrismForms.Tests
 			base.RegisterTypes();
 
 			RegisterMockType(() => onIRepoMockCreated);
+			RegisterMockType<IService>();
 		}
 
 #if IS_MSTEST
@@ -144,6 +145,22 @@ namespace Ease.XUnit.Unity.PrismForms.Tests
 			vm.DoSaveData();
 
 			ValidateMock<IRepo>(m => m.Verify(i => i.SaveData(), Times.Once));
+		}
+
+#if IS_MSTEST
+		[TestMethod]
+#elif IS_NUNIT
+		[Test]
+#elif IS_XUNIT
+		[Fact]
+#endif
+		public async Task VmCallsServiceLongRunningTaskWhenDoLongRunningTask()
+		{
+			var vm = ResolveType<VM>();
+
+			await vm.DoLongRunningTask();
+
+			ValidateMock<IService>(m => m.Verify(i => i.LongRunningTask(), Times.Once));
 		}
 
 

--- a/tests/CommonFiles/ScopeTest.cs
+++ b/tests/CommonFiles/ScopeTest.cs
@@ -340,7 +340,7 @@ namespace Ease.XUnit.Unity.PrismForms.Tests
 #elif IS_XUNIT
 		[Fact]
 #endif
-		public async Task VmCallsNavigationServicecWhenGoBackAsync()
+		public async Task VmCallsNavigationServiceWhenGoBackAsync()
 		{
 			var vm = ResolveType<VM>();
 
@@ -356,7 +356,7 @@ namespace Ease.XUnit.Unity.PrismForms.Tests
 #elif IS_XUNIT
 		[Fact]
 #endif
-		public async Task VmCallsNavigationServicecWhenGoBackAsyncParametersCheckingSpecificParameters()
+		public async Task VmCallsNavigationServiceWhenGoBackAsyncParametersCheckingSpecificParameters()
 		{
 			var vm = ResolveType<VM>();
 			var navigationParameters = new NavigationParameters()
@@ -399,7 +399,7 @@ namespace Ease.XUnit.Unity.PrismForms.Tests
 #elif IS_XUNIT
 		[Fact]
 #endif
-		public async Task VmCallsNavigationServicecWhenGoBackAsyncWithModalNavigation()
+		public async Task VmCallsNavigationServiceWhenGoBackAsyncWithModalNavigation()
 		{
 			var vm = ResolveType<VM>();
 			var navigationParameters = new NavigationParameters();

--- a/tests/CommonFiles/VM.cs
+++ b/tests/CommonFiles/VM.cs
@@ -8,22 +8,29 @@ namespace Ease.TestCommon
 	public class VM : BindableBase
 	{
 		private IRepo Repo { get; }
+		private IService Service { get; }
 		private INavigationService NavigationService { get; }
 
 		public string MyStringProperty { get; set; }
 
 		public string MyRepoProperty { get => Repo.MyProperty; }
 
-		public VM(INavigationService navigationService, IRepo repo)
+		public VM(INavigationService navigationService, IRepo repo, IService service)
 		{
 			NavigationService = navigationService;
 			Repo = repo;
+			Service = service;
 		}
 
 		public void DoSaveData()
 		{
 			Repo.SaveData();
 		}
+
+		public Task DoLongRunningTask()
+        {
+			return Service.LongRunningTask();
+        }
 
 		public Task DoNavigationAsync(string target)
 		{

--- a/tests/Ease.MsTest.DryIoc.PrismForms.Tests/Ease.MsTest.DryIoc.PrismForms.Tests.csproj
+++ b/tests/Ease.MsTest.DryIoc.PrismForms.Tests/Ease.MsTest.DryIoc.PrismForms.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ease.MsTest.Unity.PrismForms.Tests/Ease.MsTest.Unity.PrismForms.Tests.csproj
+++ b/tests/Ease.MsTest.Unity.PrismForms.Tests/Ease.MsTest.Unity.PrismForms.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ease.NUnit.DryIoc.PrismForms.Tests/Ease.NUnit.DryIoc.PrismForms.Tests.csproj
+++ b/tests/Ease.NUnit.DryIoc.PrismForms.Tests/Ease.NUnit.DryIoc.PrismForms.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ease.NUnit.Unity.PrismForms.Tests/Ease.NUnit.Unity.PrismForms.Tests.csproj
+++ b/tests/Ease.NUnit.Unity.PrismForms.Tests/Ease.NUnit.Unity.PrismForms.Tests.csproj
@@ -14,6 +14,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ease.XUnit.Unity.PrismForms.Tests/Ease.XUnit.Unity.PrismForms.Tests.csproj
+++ b/tests/Ease.XUnit.Unity.PrismForms.Tests/Ease.XUnit.Unity.PrismForms.Tests.csproj
@@ -15,6 +15,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Ease.xUnit.DryIoc.PrismForms.Tests/Ease.XUnit.DryIoc.PrismForms.Tests.csproj
+++ b/tests/Ease.xUnit.DryIoc.PrismForms.Tests/Ease.XUnit.DryIoc.PrismForms.Tests.csproj
@@ -15,6 +15,9 @@
     <Compile Include="..\CommonFiles\IRepo.cs" Link="IRepo.cs" />
     <Compile Include="..\CommonFiles\ScopeTest.cs" Link="ScopeTest.cs" />
     <Compile Include="..\CommonFiles\VM.cs" Link="VM.cs" />
+    <Compile Include="..\CommonFiles\IService.cs">
+      <Link>IService.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@duanenewman, resolves #11 by adding a parameterless overload for `RegisterMockType<T>`.

It was not possible to pass `null` as a parameter as suggested, due to the use of the `Func<Action<Mock<T>>>` as a parameter type, so `() => null` was used instead. This way the `Func` is resolved when used but the action that it invokes is `null` and safely checked against.